### PR TITLE
Feature/prettier fix setup

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,47 @@
+# 忽略依賴套件
+node_modules
+
+# 忽略編譯後的輸出
+dist
+build
+
+# 忽略環境變數設定檔
+.env
+.env.*
+
+# 忽略版本控制與鎖檔
+.git
+.gitignore
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+
+# 測試覆蓋率報告
+coverage
+
+# Log 檔案與紀錄
+logs
+*.log
+
+# 靜態資源或上傳資料
+public/
+static/
+uploads/
+
+# 忽略 Prettier 自己的 ignore 設定
+.prettierignore
+
+# 圖片與媒體檔案
+*.png
+*.jpg
+*.jpeg
+*.svg
+*.gif
+*.mp4
+*.webm
+
+# 可選：忽略資料庫檔案或 dump 檔
+*.sqlite
+*.sql
+*.dump
+ 

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "printWidth": 140
+}

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,7 +1,0 @@
-module.exports = {
-  semi: true, // 每行結尾加分號
-  singleQuote: false, // 使用單引號而不是雙引號
-  trailingComma: "all", // 在物件與陣列中保留尾逗號（但不加在函式參數）
-  tabWidth: 2, // 縮排使用 2 個空格
-  printWidth: 140, // 每行最多 140 字元，超過會換行
-};

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,9 @@
         "ts-node": "^10.9.2",
         "typeorm": "^0.3.22",
         "typescript": "^5.8.2"
+      },
+      "devDependencies": {
+        "prettier": "^3.5.3"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -1738,6 +1741,22 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/proxy-addr": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "start": "node dist/app.js",
     "dev": "nodemon --exec ts-node src/app.ts",
     "build": "tsc",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "format": "prettier --write \"src/**/*.{js,ts}\"",
+    "format:check": "prettier --check \"src/**/*.{js,ts}\""
   },
   "keywords": [],
   "author": "",
@@ -28,5 +30,8 @@
     "ts-node": "^10.9.2",
     "typeorm": "^0.3.22",
     "typescript": "^5.8.2"
+  },
+  "devDependencies": {
+    "prettier": "^3.5.3"
   }
 }

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -16,11 +16,7 @@ interface LoginBody {
   password: string;
 }
 
-export const register = async (
-  req: Request<{}, any, RegisterBody>,
-  res: Response,
-  next: NextFunction
-) => {
+export const register = async (req: Request<{}, any, RegisterBody>, res: Response, next: NextFunction) => {
   try {
     const { email, password, name } = req.body;
     const userRepository = AppDataSource.getRepository(User);
@@ -61,11 +57,7 @@ export const register = async (
   }
 };
 
-export const login = async (
-  req: Request<{}, any, LoginBody>,
-  res: Response,
-  next: NextFunction
-) => {
+export const login = async (req: Request<{}, any, LoginBody>, res: Response, next: NextFunction) => {
   try {
     const { email, password } = req.body;
     const userRepository = AppDataSource.getRepository(User);

--- a/src/entities/Order.ts
+++ b/src/entities/Order.ts
@@ -1,11 +1,4 @@
-import {
-  Entity,
-  PrimaryGeneratedColumn,
-  Column,
-  CreateDateColumn,
-  UpdateDateColumn,
-  ManyToOne,
-} from "typeorm";
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, ManyToOne } from "typeorm";
 import { User } from "./User";
 
 export enum OrderStatus {

--- a/src/entities/User.ts
+++ b/src/entities/User.ts
@@ -1,11 +1,4 @@
-import {
-  Entity,
-  PrimaryGeneratedColumn,
-  Column,
-  CreateDateColumn,
-  UpdateDateColumn,
-  OneToMany,
-} from "typeorm";
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, OneToMany } from "typeorm";
 import { Order } from "./Order";
 
 @Entity("users")

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -16,11 +16,7 @@ declare global {
   }
 }
 
-export const authMiddleware = (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): void => {
+export const authMiddleware = (req: Request, res: Response, next: NextFunction): void => {
   try {
     const token = req.headers.authorization?.split(" ")[1];
 

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -3,27 +3,21 @@ import * as userController from "../controllers/userController";
 
 const router = Router();
 
-router.post(
-  "/register",
-  async (req: Request, res: Response, next: NextFunction) => {
-    try {
-      await userController.register(req, res, next);
-    } catch (error) {
-      next(error);
-    }
+router.post("/register", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    await userController.register(req, res, next);
+  } catch (error) {
+    next(error);
   }
-);
+});
 
-router.post(
-  "/login",
-  async (req: Request, res: Response, next: NextFunction) => {
-    try {
-      await userController.login(req, res, next);
-    } catch (error) {
-      next(error);
-    }
+router.post("/login", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    await userController.login(req, res, next);
+  } catch (error) {
+    next(error);
   }
-);
+});
 
 router.post("/logout", (req: Request, res: Response, next: NextFunction) => {
   try {

--- a/src/utils/errorHandler.ts
+++ b/src/utils/errorHandler.ts
@@ -4,12 +4,7 @@ interface CustomError extends Error {
   status?: number;
 }
 
-export const errorHandler = (
-  err: CustomError,
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
+export const errorHandler = (err: CustomError, req: Request, res: Response, next: NextFunction) => {
   console.error(err.stack);
 
   const statusCode = err.status || 500;


### PR DESCRIPTION
## 主要更動

安裝 Prettier：
```
   npm install --save-dev prettier
```

修改 .prettierrc.js 的內容如下
```
   module.exports = {
     semi: true, // 每行結尾加分號
     singleQuote: false, // 使用單引號而不是雙引號
     trailingComma: "all", // 在物件與陣列中保留尾逗號
     tabWidth: 2, // 縮排使用 2 個空格
     printWidth: 140, // 每行最多 140 字元，超過會換行
   };
```

在 package.json 中添加 Prettier 相關的 script：
```
   "scripts": {
     "format": "prettier --write \"src/**/*.{js,ts}\"",
     "format:check": "prettier --check \"src/**/*.{js,ts}\""
   }
```

* 可以使用 npm run format:check 來確認格式有問題的所有檔案。

* 可以使用 npm run format 來格式化所有檔案，或是在儲存檔案時自動格式化。


將 .prettierrc.js  改為用新的 .prettierrc 檔案 (可能較穩定)，內容如下：

```
{
  "semi": true,
  "singleQuote": false,
  "trailingComma": "all",
  "tabWidth": 2,
  "printWidth": 140
}
```


## 無法順利格式化問題解法參考


在 Cursor or VScode  中重新載入視窗（Command + Shift + P，然後輸入 "Reload Window"）
確認 Prettier 擴充套件已正確安裝
如果執行以上步驟後仍然無法正常運作，您可以：
在命令面板（Command + Shift + P）中輸入 "Format Document With..."
選擇 "Prettier" 作為格式化工具
嘗試手動格式化一個文件，看看是否有任何錯誤訊息